### PR TITLE
Change the lock approach for the event registry unique instance

### DIFF
--- a/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
+++ b/modules/flowable-cmmn-engine/src/main/java/org/flowable/cmmn/engine/CmmnEngineConfiguration.java
@@ -734,6 +734,17 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
      */
     protected boolean eventRegistryStartCaseInstanceAsync = false;
 
+    /**
+     * Whether the check for unique case instances should be done with a lock.
+     * We do not recommend changing this property, unless you have been explicitly asked by a Flowable maintainer.
+     */
+    protected boolean eventRegistryUniqueCaseInstanceCheckWithLock = true;
+
+    /**
+     * The amount of time for the lock of a unique start event.
+     */
+    protected Duration eventRegistryUniqueCaseInstanceStartLockTime = Duration.ofMinutes(10);
+
     protected BusinessCalendarManager businessCalendarManager;
 
     /**
@@ -1678,6 +1689,7 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
         this.eventSubscriptionServiceConfiguration.setIdGenerator(this.idGenerator);
         this.eventSubscriptionServiceConfiguration.setObjectMapper(this.objectMapper);
         this.eventSubscriptionServiceConfiguration.setEventDispatcher(this.eventDispatcher);
+        this.eventSubscriptionServiceConfiguration.setEventSubscriptionLockTime(this.eventRegistryUniqueCaseInstanceStartLockTime);
         
         this.eventSubscriptionServiceConfiguration.init();
 
@@ -3264,6 +3276,24 @@ public class CmmnEngineConfiguration extends AbstractEngineConfiguration impleme
 
     public CmmnEngineConfiguration setEventRegistryStartCaseInstanceAsync(boolean eventRegistryStartCaseInstanceAsync) {
         this.eventRegistryStartCaseInstanceAsync = eventRegistryStartCaseInstanceAsync;
+        return this;
+    }
+
+    public boolean isEventRegistryUniqueCaseInstanceCheckWithLock() {
+        return eventRegistryUniqueCaseInstanceCheckWithLock;
+    }
+
+    public CmmnEngineConfiguration setEventRegistryUniqueCaseInstanceCheckWithLock(boolean eventRegistryUniqueCaseInstanceCheckWithLock) {
+        this.eventRegistryUniqueCaseInstanceCheckWithLock = eventRegistryUniqueCaseInstanceCheckWithLock;
+        return this;
+    }
+
+    public Duration getEventRegistryUniqueCaseInstanceStartLockTime() {
+        return eventRegistryUniqueCaseInstanceStartLockTime;
+    }
+
+    public CmmnEngineConfiguration setEventRegistryUniqueCaseInstanceStartLockTime(Duration eventRegistryUniqueCaseInstanceStartLockTime) {
+        this.eventRegistryUniqueCaseInstanceStartLockTime = eventRegistryUniqueCaseInstanceStartLockTime;
         return this;
     }
 

--- a/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventregistry/EventSubscriptionLockingTest.testConcurrentStarts.cmmn
+++ b/modules/flowable-cmmn-engine/src/test/resources/org/flowable/cmmn/test/eventregistry/EventSubscriptionLockingTest.testConcurrentStarts.cmmn
@@ -5,21 +5,24 @@
         <extensionElements>
             <flowable:eventType>myEvent</flowable:eventType>
             <flowable:startEventCorrelationConfiguration><![CDATA[storeAsUniqueReferenceId]]></flowable:startEventCorrelationConfiguration>
+            <flowable:eventOutParameter source="customerId" target="customerId"/>
         </extensionElements>
         <casePlanModel id="onecaseplanmodel1" name="Case plan model" flowable:formFieldValidation="false">
             <extensionElements>
                 <flowable:work-form-field-validation><![CDATA[false]]></flowable:work-form-field-validation>
                 <design:stencilid><![CDATA[CasePlanModel]]></design:stencilid>
             </extensionElements>
-            <planItem id="planItem1" name="My task 1" definitionRef="humanTask1"></planItem>
+            <planItem id="planItem1" name="My task 1" definitionRef="scriptTask1"></planItem>
             <planItem id="planItem2" name="My task 2" definitionRef="humanTask2"></planItem>
-            <humanTask id="humanTask1" name="My task 1" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
+            <task id="scriptTask1" name="My task 1" flowable:type="script" flowable:scriptFormat="groovy">
                 <extensionElements>
-                    <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>
-                    <design:stencilid><![CDATA[HumanTask]]></design:stencilid>
+                    <design:stencilid><![CDATA[ScriptTask]]></design:stencilid>
                     <design:stencilsuperid><![CDATA[Task]]></design:stencilsuperid>
+                    <flowable:field name="script">
+                        <flowable:string><![CDATA[Thread.sleep(1000)]]></flowable:string>
+                    </flowable:field>
                 </extensionElements>
-            </humanTask>
+            </task>
             <humanTask id="humanTask2" name="My task 2" flowable:assignee="${initiator}" flowable:formFieldValidation="false">
                 <extensionElements>
                     <flowable:start-form-field-validation><![CDATA[false]]></flowable:start-form-field-validation>

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/cmd/ReleaseLockCmd.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/cmd/ReleaseLockCmd.java
@@ -25,10 +25,12 @@ public class ReleaseLockCmd implements Command<Void> {
 
     protected String lockName;
     protected String engineType;
+    protected boolean delete;
 
-    public ReleaseLockCmd(String lockName, String engineType) {
+    public ReleaseLockCmd(String lockName, String engineType, boolean delete) {
         this.lockName = lockName;
         this.engineType = engineType;
+        this.delete = delete;
     }
 
     @Override
@@ -37,6 +39,9 @@ public class ReleaseLockCmd implements Command<Void> {
         PropertyEntity property = propertyEntityManager.findById(lockName);
         if (property != null) {
             property.setValue(null);
+            if (delete) {
+                propertyEntityManager.delete(property);
+            }
             return null;
         } else {
             throw new FlowableObjectNotFoundException("Lock with name " + lockName + " does not exist");

--- a/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/lock/LockManager.java
+++ b/modules/flowable-engine-common/src/main/java/org/flowable/common/engine/impl/lock/LockManager.java
@@ -35,9 +35,23 @@ public interface LockManager {
     boolean acquireLock();
 
     /**
+     * Acquire the lock.
+     * The {@code lockForceAcquireAfter} will be used to acquire an expired lock
+     *
+     * @param lockForceAcquireAfter the amount of time after which the lock should be acquired
+     * @return {@code true} if the lock was acquired, {@code false} otherwise
+     */
+    boolean acquireLock(Duration lockForceAcquireAfter);
+
+    /**
      * Release the lock.
      */
     void releaseLock();
+
+    /**
+     * Release the lock and delete the resources for the lock if needed.
+     */
+    void releaseAndDeleteLock();
 
     /**
      * Wait to acquire a lock, once a lock is acquired execute the supplier and release finally the lock.

--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -843,6 +843,17 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     protected boolean eventRegistryStartProcessInstanceAsync = false;
 
     /**
+     * Whether the check for unique process instances should be done with a lock.
+     * We do not recommend changing this property, unless you have been explicitly asked by a Flowable maintainer.
+     */
+    protected boolean eventRegistryUniqueProcessInstanceCheckWithLock = true;
+
+    /**
+     * The amount of time for the lock of a unique start event.
+     */
+    protected Duration eventRegistryUniqueProcessInstanceStartLockTime = Duration.ofMinutes(10);
+
+    /**
      * Set this to true if you want to have extra checks on the BPMN xml that is parsed. See http://www.jorambarrez.be/blog/2013/02/19/uploading-a-funny-xml -can-bring-down-your-server/
      * <p>
      * Unfortunately, this feature is not available on some platforms (JDK 6, JBoss), hence the reason why it is disabled by default. If your platform allows the use of StaxSource during XML parsing,
@@ -1540,6 +1551,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         this.eventSubscriptionServiceConfiguration.setIdGenerator(this.idGenerator);
         this.eventSubscriptionServiceConfiguration.setObjectMapper(this.objectMapper);
         this.eventSubscriptionServiceConfiguration.setEventDispatcher(this.eventDispatcher);
+        this.eventSubscriptionServiceConfiguration.setEventSubscriptionLockTime(this.eventRegistryUniqueProcessInstanceStartLockTime);
         
         this.eventSubscriptionServiceConfiguration.init();
         
@@ -4005,6 +4017,24 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     public ProcessEngineConfigurationImpl setEventRegistryStartProcessInstanceAsync(boolean eventRegistryStartProcessInstanceAsync) {
         this.eventRegistryStartProcessInstanceAsync = eventRegistryStartProcessInstanceAsync;
+        return this;
+    }
+
+    public boolean isEventRegistryUniqueProcessInstanceCheckWithLock() {
+        return eventRegistryUniqueProcessInstanceCheckWithLock;
+    }
+
+    public ProcessEngineConfigurationImpl setEventRegistryUniqueProcessInstanceCheckWithLock(boolean eventRegistryUniqueProcessInstanceCheckWithLock) {
+        this.eventRegistryUniqueProcessInstanceCheckWithLock = eventRegistryUniqueProcessInstanceCheckWithLock;
+        return this;
+    }
+
+    public Duration getEventRegistryUniqueProcessInstanceStartLockTime() {
+        return eventRegistryUniqueProcessInstanceStartLockTime;
+    }
+
+    public ProcessEngineConfigurationImpl setEventRegistryUniqueProcessInstanceStartLockTime(Duration eventRegistryUniqueProcessInstanceStartLockTime) {
+        this.eventRegistryUniqueProcessInstanceStartLockTime = eventRegistryUniqueProcessInstanceStartLockTime;
         return this;
     }
 

--- a/modules/flowable-engine/src/test/resources/org/flowable/engine/test/eventregistry/EventSubscriptionLockingTest.testConcurrentStarts.bpmn20.xml
+++ b/modules/flowable-engine/src/test/resources/org/flowable/engine/test/eventregistry/EventSubscriptionLockingTest.testConcurrentStarts.bpmn20.xml
@@ -10,11 +10,20 @@
         <extensionElements>
             <flowable:eventType>myEvent</flowable:eventType>
             <flowable:startEventCorrelationConfiguration><![CDATA[storeAsUniqueReferenceId]]></flowable:startEventCorrelationConfiguration>
+            <flowable:eventOutParameter source="customerId" target="customerId"/>
         </extensionElements>
     </startEvent>
     
-    <sequenceFlow sourceRef="theStart" targetRef="task" />
-    
+    <sequenceFlow sourceRef="theStart" targetRef="scriptTask" />
+
+    <scriptTask id="scriptTask" name="Script Task " scriptFormat="groovy" >
+        <script>
+            <![CDATA[Thread.sleep(1000)]]>
+        </script>
+    </scriptTask>
+
+    <sequenceFlow sourceRef="scriptTask" targetRef="task" />
+
     <userTask id="task" />
   	
   	<sequenceFlow sourceRef="task" targetRef="theEnd" />

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/ProcessEngineAutoConfiguration.java
@@ -257,6 +257,8 @@ public class ProcessEngineAutoConfiguration extends AbstractSpringEngineAutoConf
         conf.setProcessDefinitionCacheLimit(processProperties.getDefinitionCacheLimit());
         conf.setEnableSafeBpmnXml(processProperties.isEnableSafeXml());
         conf.setEventRegistryStartProcessInstanceAsync(processProperties.isEventRegistryStartProcessInstanceAsync());
+        conf.setEventRegistryUniqueProcessInstanceCheckWithLock(processProperties.isEventRegistryUniqueProcessInstanceCheckWithLock());
+        conf.setEventRegistryUniqueProcessInstanceStartLockTime(processProperties.getEventRegistryUniqueProcessInstanceStartLockTime());
 
         conf.setHistoryLevel(flowableProperties.getHistoryLevel());
         

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/CmmnEngineAutoConfiguration.java
@@ -225,6 +225,8 @@ public class CmmnEngineAutoConfiguration extends AbstractSpringEngineAutoConfigu
 
         configuration.setEnableSafeCmmnXml(cmmnProperties.isEnableSafeXml());
         configuration.setEventRegistryStartCaseInstanceAsync(cmmnProperties.isEventRegistryStartCaseInstanceAsync());
+        configuration.setEventRegistryUniqueCaseInstanceCheckWithLock(cmmnProperties.isEventRegistryUniqueCaseInstanceCheckWithLock());
+        configuration.setEventRegistryUniqueCaseInstanceStartLockTime(cmmnProperties.getEventRegistryUniqueCaseInstanceStartLockTime());
 
         configuration.setFormFieldValidationEnabled(flowableProperties.isFormFieldValidationEnabled());
 

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/FlowableCmmnProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/cmmn/FlowableCmmnProperties.java
@@ -12,6 +12,7 @@
  */
 package org.flowable.spring.boot.cmmn;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
@@ -66,6 +67,22 @@ public class FlowableCmmnProperties {
      * This is a fallback applied for all events. We suggest modelling your cases appropriately, i.e. marking the start of the case as async
      */
     private boolean eventRegistryStartCaseInstanceAsync = false;
+
+    /**
+     * Whether case instances should be started asynchronously from an event registry.
+     * This is a fallback applied for all events. We suggest modelling your cases appropriately, i.e. marking the start of the case as async
+     */
+
+    /**
+     * Whether the check for unique case instances should be done with a lock.
+     * We do not recommend changing this property, unless you have been explicitly asked by a Flowable maintainer.
+     */
+    private boolean eventRegistryUniqueCaseInstanceCheckWithLock = true;
+
+    /**
+     * The amount of time for the lock of a unique start event.
+     */
+    private Duration eventRegistryUniqueCaseInstanceStartLockTime = Duration.ofMinutes(10);
 
     /**
      * The servlet configuration for the CMMN Rest API.
@@ -127,6 +144,22 @@ public class FlowableCmmnProperties {
 
     public void setEventRegistryStartCaseInstanceAsync(boolean eventRegistryStartCaseInstanceAsync) {
         this.eventRegistryStartCaseInstanceAsync = eventRegistryStartCaseInstanceAsync;
+    }
+
+    public boolean isEventRegistryUniqueCaseInstanceCheckWithLock() {
+        return eventRegistryUniqueCaseInstanceCheckWithLock;
+    }
+
+    public void setEventRegistryUniqueCaseInstanceCheckWithLock(boolean eventRegistryUniqueCaseInstanceCheckWithLock) {
+        this.eventRegistryUniqueCaseInstanceCheckWithLock = eventRegistryUniqueCaseInstanceCheckWithLock;
+    }
+
+    public Duration getEventRegistryUniqueCaseInstanceStartLockTime() {
+        return eventRegistryUniqueCaseInstanceStartLockTime;
+    }
+
+    public void setEventRegistryUniqueCaseInstanceStartLockTime(Duration eventRegistryUniqueCaseInstanceStartLockTime) {
+        this.eventRegistryUniqueCaseInstanceStartLockTime = eventRegistryUniqueCaseInstanceStartLockTime;
     }
 
     public FlowableServlet getServlet() {

--- a/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/process/FlowableProcessProperties.java
+++ b/modules/flowable-spring-boot/flowable-spring-boot-starters/flowable-spring-boot-autoconfigure/src/main/java/org/flowable/spring/boot/process/FlowableProcessProperties.java
@@ -12,6 +12,8 @@
  */
 package org.flowable.spring.boot.process;
 
+import java.time.Duration;
+
 import org.flowable.spring.boot.FlowableServlet;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -52,6 +54,17 @@ public class FlowableProcessProperties {
      */
     private boolean eventRegistryStartProcessInstanceAsync = false;
 
+    /**
+     * Whether the check for unique process instances should be done with a lock.
+     * We do not recommend changing this property, unless you have been explicitly asked by a Flowable maintainer.
+     */
+    private boolean eventRegistryUniqueProcessInstanceCheckWithLock = true;
+
+    /**
+     * The amount of time for the lock of a unique start event.
+     */
+    private Duration eventRegistryUniqueProcessInstanceStartLockTime = Duration.ofMinutes(10);
+
     public FlowableServlet getServlet() {
         return servlet;
     }
@@ -86,6 +99,22 @@ public class FlowableProcessProperties {
 
     public void setEventRegistryStartProcessInstanceAsync(boolean eventRegistryStartProcessInstanceAsync) {
         this.eventRegistryStartProcessInstanceAsync = eventRegistryStartProcessInstanceAsync;
+    }
+
+    public boolean isEventRegistryUniqueProcessInstanceCheckWithLock() {
+        return eventRegistryUniqueProcessInstanceCheckWithLock;
+    }
+
+    public void setEventRegistryUniqueProcessInstanceCheckWithLock(boolean eventRegistryUniqueProcessInstanceCheckWithLock) {
+        this.eventRegistryUniqueProcessInstanceCheckWithLock = eventRegistryUniqueProcessInstanceCheckWithLock;
+    }
+
+    public Duration getEventRegistryUniqueProcessInstanceStartLockTime() {
+        return eventRegistryUniqueProcessInstanceStartLockTime;
+    }
+
+    public void setEventRegistryUniqueProcessInstanceStartLockTime(Duration eventRegistryUniqueProcessInstanceStartLockTime) {
+        this.eventRegistryUniqueProcessInstanceStartLockTime = eventRegistryUniqueProcessInstanceStartLockTime;
     }
 
     public static class AsyncHistory {


### PR DESCRIPTION
Change the approach for locking for the check of a unique instance. It is possible to have multiple threads trying to start independent unique instances. When the lock is done on the event registry then only one of the instances (instead of the 2) will be created.

With the new approach we are using our lock manager to acquire a lock specific to the unique values for the instance that will be created. This means that both of the instances from the scenario above will be created

#### Check List:
* Unit tests: YES / NO / NA
* Documentation: YES / NO / NA
